### PR TITLE
Add new (V1.9.0+) logs which use gyroADC (old logs use gyroData)

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -462,7 +462,7 @@ function FlightLog(logData) {
      */
     function injectComputedFields(sourceChunks, destChunks) {
         var
-            gyroData = [fieldNameToIndex["gyroData[0]"], fieldNameToIndex["gyroData[1]"], fieldNameToIndex["gyroData[2]"]], 
+            gyroADC, 
             accSmooth = [fieldNameToIndex["accSmooth[0]"], fieldNameToIndex["accSmooth[1]"], fieldNameToIndex["accSmooth[2]"]],
             magADC = [fieldNameToIndex["magADC[0]"], fieldNameToIndex["magADC[1]"], fieldNameToIndex["magADC[2]"]],
             
@@ -475,6 +475,12 @@ function FlightLog(logData) {
                        [fieldNameToIndex["axisP[1]"], fieldNameToIndex["axisI[1]"], fieldNameToIndex["axisD[1]"]],
                        [fieldNameToIndex["axisP[2]"], fieldNameToIndex["axisI[2]"], fieldNameToIndex["axisD[2]"]]];
         
+		if (fieldNameToIndex["gyroData[0]"] > 0) {
+ 			gyroADC = [fieldNameToIndex["gyroData[0]"], fieldNameToIndex["gyroData[1]"], fieldNameToIndex["gyroData[2]"]];
+		} else {
+ 			gyroADC = [fieldNameToIndex["gyroADC[0]"], fieldNameToIndex["gyroADC[1]"], fieldNameToIndex["gyroADC[2]"]];
+		}
+
         if (destChunks.length === 0) {
             return;
         }
@@ -512,7 +518,7 @@ function FlightLog(logData) {
                         fieldIndex = destFrame.length - ADDITIONAL_COMPUTED_FIELD_COUNT;
                     
                     attitude = chunkIMU.updateEstimatedAttitude(
-                        [srcFrame[gyroData[0]], srcFrame[gyroData[1]], srcFrame[gyroData[2]]],
+                        [srcFrame[gyroADC[0]], srcFrame[gyroADC[1]], srcFrame[gyroADC[2]]],
                         [srcFrame[accSmooth[0]], srcFrame[accSmooth[1]], srcFrame[accSmooth[2]]],
                         srcFrame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME], 
                         sysConfig.acc_1G, 

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -28,6 +28,11 @@ function FlightLogFieldPresenter() {
         'gyroData[0]': 'gyro[roll]',
         'gyroData[1]': 'gyro[pitch]',
         'gyroData[2]': 'gyro[yaw]',
+
+        'gyroADC[all]': 'gyro',
+        'gyroADC[0]': 'gyro[roll]',
+        'gyroADC[1]': 'gyro[pitch]',
+        'gyroADC[2]': 'gyro[yaw]',
     
         'accSmooth[all]': 'acc',
         'accSmooth[0]': 'acc[X]',
@@ -116,6 +121,9 @@ function FlightLogFieldPresenter() {
             case 'gyroData[0]':
             case 'gyroData[1]':
             case 'gyroData[2]':
+            case 'gyroADC[0]':
+            case 'gyroADC[1]':
+            case 'gyroADC[2]':
                 return Math.round(flightLog.gyroRawToDegreesPerSecond(value)) + " deg/s";
                 
             case 'accSmooth[0]':

--- a/js/flightlog_index.js
+++ b/js/flightlog_index.js
@@ -52,7 +52,7 @@ function FlightLogIndex(logData) {
                 },
                 
                 imu = new IMU(),
-                gyroData, accSmooth, magADC,
+                gyroADC, accSmooth, magADC,
                 
                 iframeCount = 0,
                 motorFields = [],
@@ -77,12 +77,18 @@ function FlightLogIndex(logData) {
                     sysConfig = parser.sysConfig,
                     mainFrameDef = parser.frameDefs.I,
                     
-                    gyroData = [mainFrameDef.nameToIndex["gyroData[0]"], mainFrameDef.nameToIndex["gyroData[1]"], mainFrameDef.nameToIndex["gyroData[2]"]],
+                    gyroADC, 
                     accSmooth = [mainFrameDef.nameToIndex["accSmooth[0]"], mainFrameDef.nameToIndex["accSmooth[1]"], mainFrameDef.nameToIndex["accSmooth[2]"]],
                     magADC = [mainFrameDef.nameToIndex["magADC[0]"], mainFrameDef.nameToIndex["magADC[1]"], mainFrameDef.nameToIndex["magADC[2]"]],
                     
                     lastSlow = [],
                     lastGPSHome = [];
+
+				if (mainFrameDef.nameToIndex["gyroData[0]"] > 0) {
+						gyroADC = [mainFrameDef.nameToIndex["gyroData[0]"], mainFrameDef.nameToIndex["gyroData[1]"], mainFrameDef.nameToIndex["gyroData[2]"]];
+					} else {
+						gyroADC = [mainFrameDef.nameToIndex["gyroADC[0]"], mainFrameDef.nameToIndex["gyroADC[1]"], mainFrameDef.nameToIndex["gyroADC[2]"]];
+					}
                 
                 // Identify motor fields so they can be used to show the activity summary bar
                 for (var j = 0; j < 8; j++) {
@@ -144,7 +150,7 @@ function FlightLogIndex(logData) {
                             }
                             
                             imu.updateEstimatedAttitude(
-                                [frame[gyroData[0]], frame[gyroData[1]], frame[gyroData[2]]],
+                                [frame[gyroADC[0]], frame[gyroADC[1]], frame[gyroADC[2]]],
                                 [frame[accSmooth[0]], frame[accSmooth[1]], frame[accSmooth[2]]],
                                 frame[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME], 
                                 sysConfig.acc_1G, 

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -136,7 +136,7 @@ GraphConfig.PALETTE = [
             },
             {
                 label: "Gyros",
-                fields: ["gyroData[all]"]
+				fields: ["gyroADC[all]"]				
             },
             {
                 label: "PIDs",
@@ -144,15 +144,15 @@ GraphConfig.PALETTE = [
             },
             {
                 label: "Gyro + PID roll",
-                fields: ["axisP[0]", "axisI[0]", "axisD[0]", "gyroData[0]"]
+                fields: ["axisP[0]", "axisI[0]", "axisD[0]", "gyroADC[0]"]
             },
             {
                 label: "Gyro + PID pitch",
-                fields: ["axisP[1]", "axisI[1]", "axisD[1]", "gyroData[1]"]
+                fields: ["axisP[1]", "axisI[1]", "axisD[1]", "gyroADC[1]"]
             },
             {
                 label: "Gyro + PID yaw",
-                fields: ["axisP[2]", "axisI[2]", "axisD[2]", "gyroData[2]"]
+                fields: ["axisP[2]", "axisI[2]", "axisD[2]", "gyroADC[2]"]
             },
             {
                 label: "Accelerometers",
@@ -166,6 +166,8 @@ GraphConfig.PALETTE = [
         } else if (fieldName.match(/^servo\[/)) {
             return 5000;
         } else if (fieldName.match(/^gyroData\[/)) {
+            return 3000;
+        } else if (fieldName.match(/^gyroADC\[/)) {
             return 3000;
         } else if (fieldName.match(/^accSmooth\[/)) {
             return 3000;
@@ -194,7 +196,7 @@ GraphConfig.PALETTE = [
                 inputRange: 500,
                 outputRange: 1.0
             };
-        } else if (fieldName.match(/^gyroData\[/)) {
+        } else if (fieldName.match(/^gyroData\[/) || fieldName.match(/^gyroADC\[/)) {
             return {
                 offset: 0,
                 power: 0.25,

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -150,6 +150,10 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, craftCanvas) {
                 var axisIndex = matches[1];
 
                 idents.gyroFields[axisIndex] = fieldIndex;
+            } else if ((matches = fieldName.match(/^gyroADC\[(\d+)]$/))) {
+                var axisIndex = matches[1];
+
+                idents.gyroFields[axisIndex] = fieldIndex;
             } else if ((matches = fieldName.match(/^accSmooth\[(\d+)]$/))) {
                 var axisIndex = matches[1];
 

--- a/js/imu.js
+++ b/js/imu.js
@@ -133,7 +133,7 @@ function IMU(copyFrom) {
     /**
      * Using the given raw data, update the IMU state and return the new estimate for the attitude.
      */
-    this.updateEstimatedAttitude = function(gyroData, accSmooth, currentTime, acc_1G, gyroScale, magADC) {
+    this.updateEstimatedAttitude = function(gyroADC, accSmooth, currentTime, acc_1G, gyroScale, magADC) {
         var 
             accMag = 0,
             deltaTime,
@@ -151,7 +151,7 @@ function IMU(copyFrom) {
         
         // Initialization
         for (var axis = 0; axis < 3; axis++) {
-            deltaGyroAngle[axis] = gyroData[axis] * scale;
+            deltaGyroAngle[axis] = gyroADC[axis] * scale;
         
             accMag += accSmooth[axis] * accSmooth[axis];
         }


### PR DESCRIPTION
Backwards compatible Blacklog Viewer to view new V1.9.0 logs as well as previous version Blackbox logs.
