### PR TITLE
Rebrand the API URL for latest version to CleanFlight

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -811,7 +811,7 @@ function BlackboxLogViewer() {
         $("#viewer-version").text('You are using version ' + VIEWER_VERSION);
         $(".viewer-version", statusBar).text('v'+VIEWER_VERSION);
         try {
-            $.getJSON('https://api.github.com/repos/betaflight/blackbox-log-viewer/releases/latest',{},function(data){
+            $.getJSON('https://api.github.com/repos/cleanflight/blackbox-log-viewer/releases/latest',{},function(data){
                 latestVersion = data;
                 if(latestVersion) {
                     $(".btn-viewer-download").text(latestVersion.tag_name);


### PR DESCRIPTION
Changes the API URL address to verify latest version of BlackBox viewer, from BetaFlight to CleanFlight..