### PR TITLE
Accept the new yaw rate and expo values

### DIFF
--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -422,8 +422,7 @@ var FlightLogParser = function(logData) {
             break;
             case "rcRate":
             case "rcExpo":
-            case "rcYawExpo":
-            case "rcYawRate":
+            case "rcYawExpo":            
             case "thrMid":
             case "thrExpo":
             case "dynThrPID":
@@ -477,7 +476,12 @@ var FlightLogParser = function(logData) {
             case "debug_mode":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
-
+            
+            case "rc_rate_yaw":
+            case "rcYawRate":
+                that.sysConfig.rcYawRate = parseInt(fieldValue, 10);
+            break;
+               
             case "yawRateAccelLimit":
             case "rateAccelLimit":
             case "anti_gravity_gain":

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -421,8 +421,7 @@ var FlightLogParser = function(logData) {
                 that.sysConfig.motorOutput[1] = that.sysConfig[fieldName]; // by default, set the maxMotorOutput to match maxThrottle
             break;
             case "rcRate":
-            case "rcExpo":
-            case "rcYawExpo":            
+            case "rcExpo":                        
             case "thrMid":
             case "thrExpo":
             case "dynThrPID":
@@ -476,12 +475,17 @@ var FlightLogParser = function(logData) {
             case "debug_mode":
                 that.sysConfig[fieldName] = parseInt(fieldValue, 10);
             break;
-            
+                        	
             case "rc_rate_yaw":
             case "rcYawRate":
                 that.sysConfig.rcYawRate = parseInt(fieldValue, 10);
             break;
-               
+            
+            case "rc_yaw_expo":
+            case "rcYawExpo":            
+				that.sysConfig.rcYawExpo = parseInt(fieldValue, 10);
+            break;
+
             case "yawRateAccelLimit":
             case "rateAccelLimit":
             case "anti_gravity_gain":


### PR DESCRIPTION
The new versions of CF/BF use two new strings for the YAW rate and YAW expo. For example:
```
H rc_rate_yaw:100
H rc_yaw_expo:25
```
This PR accepts the new values.