### PR TITLE
Adjust amperage readings to latest version

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -351,8 +351,10 @@ function FlightLogFieldPresenter() {
                 }
 
             case 'amperageLatest':
-                if((flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.0')) ||
+                if((flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.7')) ||
                    (flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '2.0.0'))) {
+                    return (value / 100).toFixed(2) + "A" + ", " + (value / 100 / flightLog.getNumMotors()).toFixed(2) + "A/motor";
+                } else if(flightLog.getSysConfig().firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(flightLog.getSysConfig().firmwareVersion, '3.1.0')) {
                     return (value / 10).toFixed(2) + "A" + ", " + (value / 10 / flightLog.getNumMotors()).toFixed(2) + "A/motor";
                 } else {
                     return (flightLog.amperageADCToMillivolts(value) / 1000).toFixed(2) + "A" + ", " + (flightLog.amperageADCToMillivolts(value) / 1000 / flightLog.getNumMotors()).toFixed(2) + "A/motor";

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -270,6 +270,7 @@ var FlightLogParser = function(logData) {
             accel_limit               : "rateAccelLimit",
             acc_limit                 : "rateAccelLimit",
             anti_gravity_thresh       : "anti_gravity_threshold",
+            currentSensor             : "currentMeter",
             d_notch_cut               : "dterm_notch_cutoff", 
             d_setpoint_weight         : "dtermSetpointWeight",
             dterm_setpoint_weight     : "dtermSetpointWeight",  


### PR DESCRIPTION
Since CF2.0/BF3.1.7 the amperage must be divided into 100. Since now it was divided into 10.

This is being discused into https://github.com/betaflight/blackbox-log-viewer/issues/48
