### PR TITLE
Refresh graph when start-log-here

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1068,7 +1068,7 @@ function BlackboxLogViewer() {
         $(".log-play-pause").click(logPlayPause);
         
         var logSyncHere = function() {
-            setVideoOffset(video.currentTime);
+            setVideoOffset(video.currentTime, true);
         };
         $(".log-sync-here").click(logSyncHere);
         


### PR DESCRIPTION
When pressed the start-log-here (to sync a video with the beep of the blackbox log) and the video is paused, the graph is
not refreshed until some other operation refreshes it.