### PR TITLE
Add a button to create a new blackbox log viewer window

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,8 @@
             <div id="navbar" class="navbar-collapse collapse">
                 <div class="navbar-form navbar-right" role="form">
                     <div class="btn-group">
-                        <a class="btn btn-default btn-video-export" data-toggle="tooltip" title="Export your vide and chart setup to file"> Export video...</a>
+                        <a class="btn btn-default btn-new-window" data-toggle="tooltip" title="Open a new Blackbox Log Viewer window"> New Window </a>
+                        <a class="btn btn-primary btn-video-export" data-toggle="tooltip" title="Export your vide and chart setup to file"> Export video...</a>
                         <a class="btn btn-primary btn-workspaces-export" data-toggle="tooltip" title="Export your workspace configurations to file"> Export Workspaces...</a>
                         <span class="btn btn-primary btn-file" data-toggle="tooltip" title="Open another log file, video file, exported workspace file or configuration dump file"> Open log file/video <input type="file" class="file-open" multiple></span>
                         <button type="button" class="btn btn-default view-zoom-in" data-toggle="tooltip" title="Zoom In Window" style="display: none;">

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,9 @@ var userSettings = {};
 
 var VIEWER_VERSION = '2.5.11'; // Current version
 
+var INNER_BOUNDS_WIDTH  = 1340,
+    INNER_BOUNDS_HEIGHT = 900;
+
 function BlackboxLogViewer() {
     function supportsRequiredAPIs() {
         return window.File && window.FileReader && window.FileList && Modernizr.canvas;
@@ -863,6 +866,15 @@ function BlackboxLogViewer() {
         hasAnalyser = false;
         html.toggleClass("has-analyser", hasAnalyser);
 
+        $(".btn-new-window").click(function(e) {            
+            chrome.app.window.create('index.html', {
+                'innerBounds' : {
+                    'width'  : INNER_BOUNDS_WIDTH,
+                    'height' : INNER_BOUNDS_HEIGHT
+                }
+            });            
+        });
+        
         $(".file-open").change(function(e) {
             var 
                 files = e.target.files,


### PR DESCRIPTION
This adds a new button that opens a new Blackbox Log Viewer window. In this way is easier to compare two different logs.

![image](https://user-images.githubusercontent.com/2673520/33445413-10b42478-d5fd-11e7-857a-906e8b03c27e.png)
